### PR TITLE
connpool with Close() method

### DIFF
--- a/connpool.go
+++ b/connpool.go
@@ -63,9 +63,6 @@ type ConnPool interface {
 	// Don't try to call it in runtime: not thread safe.
 	RegisterServer(addr string)
 
-	// Size get current pool size
-	Size() int
-
 	// Close drain all opened connections and deregister servers
 	Close() error
 }

--- a/connpool.go
+++ b/connpool.go
@@ -1,7 +1,6 @@
 // Package goconnpool implements connections pool with ratelimits and backoff for broken connections.
 //
 // Connection returned by the pool is protocol-independent.
-//
 package goconnpool
 
 import (
@@ -63,6 +62,12 @@ type ConnPool interface {
 	// This operation is a part of initialization.
 	// Don't try to call it in runtime: not thread safe.
 	RegisterServer(addr string)
+
+	// Size get current pool size
+	Size() int
+
+	// Close drain all opened connections and deregister servers
+	Close() error
 }
 
 // NewConnPool creates new pool with configuration passed.

--- a/containers.go
+++ b/containers.go
@@ -46,6 +46,16 @@ func (rr *roundRobin) next() interface{} {
 	return x
 }
 
+func (rr *roundRobin) pop() interface{} {
+	if len(rr.data) == 0 {
+		return nil
+	}
+
+	x := rr.data[0]
+	rr.data = rr.data[1:]
+	return x
+}
+
 func (rr *roundRobin) size() int {
 	return len(rr.data)
 }

--- a/containers.go
+++ b/containers.go
@@ -46,16 +46,6 @@ func (rr *roundRobin) next() interface{} {
 	return x
 }
 
-func (rr *roundRobin) pop() interface{} {
-	if len(rr.data) == 0 {
-		return nil
-	}
-
-	x := rr.data[0]
-	rr.data = rr.data[1:]
-	return x
-}
-
 func (rr *roundRobin) size() int {
 	return len(rr.data)
 }

--- a/pool_impl.go
+++ b/pool_impl.go
@@ -148,8 +148,6 @@ func (p *connPool) Close() error {
 		if x.(connectionProvider).nOpenedConnections() == 0 {
 			continue
 		}
-
-		time.Sleep(time.Second)
 	}
 
 	return nil

--- a/pool_impl.go
+++ b/pool_impl.go
@@ -9,10 +9,6 @@ import (
 	"github.com/pkg/errors"
 )
 
-var (
-	ErrNoServersRegistered = fmt.Errorf("no registered servers found")
-)
-
 type connPool struct {
 	cfg Config
 
@@ -127,7 +123,7 @@ func (p *connPool) Close() error {
 	defer p.mu.Unlock()
 
 	if p.servers.size() == 0 {
-		return ErrNoServersRegistered
+		return nil
 	}
 
 	for i := 0; i < p.servers.size(); i++ {
@@ -143,10 +139,6 @@ func (p *connPool) Close() error {
 		x := p.servers.pop()
 		if x == nil {
 			break
-		}
-
-		if x.(connectionProvider).nOpenedConnections() == 0 {
-			continue
 		}
 	}
 


### PR DESCRIPTION
In some rare cases you may need to close connpool and reopen it later. This PR contains Close() method that drains and closes connpool.